### PR TITLE
時刻が50分台で「1時間後」を押すと60分となるバグを修正

### DIFF
--- a/kaerumail/src/jp/co/skyhobbit/kaerumail/Utility.as
+++ b/kaerumail/src/jp/co/skyhobbit/kaerumail/Utility.as
@@ -3,19 +3,15 @@ package jp.co.skyhobbit.kaerumail {
 	public class Utility {
 		
 		public static function getHHMM(minutes:Number):String {
+			const MINUTES_UNIT:int = 10; // 分を切りの良い数値にするための単位。
+			
 			var dateObject:Date = new Date();
 			var hh:Number = dateObject.getHours();
 			var mm:Number = dateObject.getMinutes();
-			var rounding:Number = 10; // 切り上げ。分を切りの良い数値にするため。
-			mm += minutes;
-			mm = int((mm + rounding - 1) / rounding) * rounding;
-			if (mm >= 60) {
-				hh += 1;
-				mm -= 60;
-			}
-			if (hh >= 24) {
-				hh -= 24;
-			}
+			mm = int((mm + minutes + MINUTES_UNIT - 1) / MINUTES_UNIT) * MINUTES_UNIT;
+			
+			hh = (hh + int(mm / 60)) % 24; 
+			mm = mm % 60;
 			return (("0" + hh.toString()).substr(-2) + ("0" + mm.toString()).substr(-2)); // 前ゼロを付加する。
 		}
 		


### PR DESCRIPTION
計算方法を変えた。
